### PR TITLE
Passthru init keys

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,6 +79,12 @@ This is a dict. By default, TinyMCE is loaded with the following options set:
 - ``language`` (taken from Django settings)
 - ``language_load``
 
+TinyMCE Init Passthru
+---------------------
+
+To pass any additional keys to the ``init()`` function of TinyMCE (`see the TinyMCE docs <https://www.tinymce.com/docs/configure/>`_),
+set the ``passthru_init_keys`` keyword arg to a dictionary of options.
+
 TinyMCE plugins and tools
 ========================= 
 

--- a/wagtailtinymce/rich_text.py
+++ b/wagtailtinymce/rich_text.py
@@ -97,6 +97,9 @@ class TinyMCERichTextArea(WidgetWithScript, widgets.Textarea):
             else:
                 kwargs['menubar'] = ' '.join(self.kwargs['menus'])
 
+        if 'passthru_init_keys' in self.kwargs:
+            kwargs.update(self.kwargs['passthru_init_keys'])
+
         return "makeTinyMCEEditable({0}, {1});".format(json.dumps(id_), json.dumps(kwargs))
 
     def value_from_datadict(self, data, files, name):


### PR DESCRIPTION
Created `passthru_init_keys` keyword arg that can be set to a dict to allow *any* TinyMCE keys to be sent to the `init()` function when setting up the TinyMCE instance.